### PR TITLE
Fix AWS (Gateway, Lambda, DynamoDB), Terraform Version.

### DIFF
--- a/gateway-dynamodb-lambda/deploy/main.tf
+++ b/gateway-dynamodb-lambda/deploy/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 5.9.0"
   access_key = "${var.access_key}"  # from variables.tf
   secret_key = "${var.secret_key}" # from variables.tf
   region     = "${var.region}"  # from variables.tf
@@ -39,7 +39,7 @@ resource "aws_lambda_function" "dynamodb_write2" {
   handler       = "index.handler"
 
   source_code_hash = "${filebase64sha256("lambda_function_payload.zip")}"
-  runtime = "nodejs12.x"
+  runtime = "nodejs18.x"
 }
 
 

--- a/gateway-dynamodb-lambda/deploy_terraform.sh
+++ b/gateway-dynamodb-lambda/deploy_terraform.sh
@@ -13,7 +13,7 @@ export TF_LOG=INFO
 export TF_LOG_PATH=./terraform.log 
 
 echo " setting DynamoDB Table name ...."
-sed -i.bak "s/TableName:.*/TableName: '$dynamodb_table_name' /g" lambda/functions/index.js
+sed -i.bak 's/"TableName":.*/"TableName": "'$dynamodb_table_name'" /g' lambda/functions/index.js
 
 echo " packaging Lambda function .... "
 cd lambda/functions/
@@ -22,5 +22,5 @@ mv lambda_function_payload.zip ../../deploy/
 cd ../../
 
 echo " Deploying via Terraform....."
-terraform -chdir=./deploy/ init 
+terraform -chdir=./deploy/ init -upgrade
 terraform -chdir=./deploy/ apply -auto-approve -var 'access_key='$access_key'' -var 'secret_key='$secret_key'' -var 'dynamodb_table_name='$dynamodb_table_name'' 

--- a/gateway-dynamodb-lambda/destroy_terraform.sh
+++ b/gateway-dynamodb-lambda/destroy_terraform.sh
@@ -12,14 +12,5 @@ read -p "Enter DynamoDB Table name:  " dynamodb_table_name
 export TF_LOG=INFO
 export TF_LOG_PATH=./terraform.log 
 
-echo " setting DynamoDB Table name ...."
-sed -i.bak "s/TableName:.*/TableName: '$dynamodb_table_name' /g" lambda/functions/index.js
 
-echo " packaging Lambda function .... "
-cd lambda/functions/
-zip lambda_function_payload.zip index.js
-mv lambda_function_payload.zip ../../
-cd ../../
-
-
-terraform destroy  -var 'access_key='$access_key'' -var 'secret_key='$secret_key''  -var 'dynamodb_table_name='$dynamodb_table_name'' deploy
+terraform -chdir=./deploy/ destroy -auto-approve -var 'access_key='$access_key'' -var 'secret_key='$secret_key''  -var 'dynamodb_table_name='$dynamodb_table_name'' 

--- a/gateway-dynamodb-lambda/test.py
+++ b/gateway-dynamodb-lambda/test.py
@@ -24,7 +24,7 @@ def _get_base_url():
     """
     base_url = ""
 
-    with open('terraform.tfstate') as json_file:
+    with open('./deploy/terraform.tfstate') as json_file:
         data = json.load(json_file)
         try:
             base_url = str(data['outputs']['base_url']['value'])


### PR DESCRIPTION
This PR updated the version of Terraform being used.

It uses NodeJS version 18 for the lambda function.

The destroy_terraform.sh script needed to be fixed.  

running `test.py` shows that data are insterted into the table. One can also see this through the AWS console by going to the DynamoDB table and scanning for rows.